### PR TITLE
保育園お迎え手順ページの更新

### DIFF
--- a/docs/mother/index.html
+++ b/docs/mother/index.html
@@ -136,32 +136,39 @@
           住所：〒820-0044 福岡県飯塚市横田351-1<br />
           <a href="https://maps.app.goo.gl/Drw7Evj1U5NyUMjb7" target="_blank" rel="noopener noreferrer">Google Mapで開く</a>
         </p>
+        <p>入口と出口が分かれています。<br />
+          出口：西側（GEO側）　／　入口：東側（王将側）</p>
       </section>
 
       <section class="card">
         <h2>間取り図</h2>
         <img class="zoomable" src="../2026-03-09_18h00_47.png" alt="横田保育園 間取り図" />
-        <p class="small">画像ファイルが未配置の場合は表示されません。</p>
       </section>
 
       <section class="card">
         <h2>手順</h2>
         <h3>① 入口でPC打刻（図の①）</h3>
         <p>入口の左側にあるパソコンで、退勤打刻をしてください。</p>
-        <p><span class="code">1歳時 → 川島知隼 → 退室</span></p>
+        <p><span class="code">2歳児 → 川島知隼 → 退室</span></p>
 
         <h3>② 知隼をピックアップ（図の②）</h3>
-        <p>廊下を奥に進み、1歳児クラスで知隼を迎えてください。</p>
+        <p>ファミサポが来ることを連絡帳に書いているので、「ファミサポです、ちはやくんを迎えに来ました」と言えば大丈夫です。</p>
 
-        <h3>(2) 知隼がいる場所のお手拭きタオルを取る</h3>
-        <p>知隼がいる場所にお手拭きタオルが掛かってあるので、取ってください。</p>
+        <h3>③ 知隼がいる場所のお手拭きタオルと水筒を取る</h3>
+        <ul>
+          <li>お手拭きタオル（知隼がいる場所に掛かっています）※毎回変わるため画像なし</li>
+          <li>水筒（水色のサーモス）</li>
+        </ul>
+        <img class="zoomable" src="../PXL_20260405_104610232.jpg" alt="知隼の水筒（水色のサーモス）" style="width: 40%; max-width: 200px;" />
 
-        <h3>③ 荷物を取る（図の③）</h3>
-        <p>★マーク（廊下の右側）にある知隼の荷物を忘れずに取ってください。</p>
+        <h3>④ リュックを取る（図の④）</h3>
+        <p>通路側にある知隼のリュックを忘れずに取ってください。</p>
         <p class="small">荷物の場所は、顔写真か名前が書いてある場所を見て確認してください。</p>
+        <img class="zoomable" src="../PXL_20260405_224311922.jpg" alt="知隼のリュック（モンスターズインク）" style="width: 40%; max-width: 200px;" />
 
-        <h3>④ 知隼の靴を取る（迎え）</h3>
-        <p>帰る前に、知隼の靴（名前が書いてあります）を忘れずに取ってください。</p>
+        <h3>⑤ 知隼の靴を取る（図の⑤）</h3>
+        <p>帰る前に、知隼の靴（名前が書いてあります）を忘れずに取ってください。※毎回変わるため画像なし</p>
+        <p>⚠️ 出口はGEO側です。入口（王将側）と間違えないようにご注意ください。</p>
       </section>
 
       <section class="card">
@@ -176,7 +183,9 @@
           住所：福岡県飯塚市立岩964-24 アルファスマート新飯塚駅東口801号室<br />
           <a href="https://share.google/Ijlxr8N1hVt0lqUsb" target="_blank" rel="noopener noreferrer">Google Mapで開く</a>
         </p>
-        <p>駐車場は、21番です。</p>
+        <p>路肩、または駐車場21番に停めてください。</p>
+        <p class="small">路肩の写真</p>
+        <img class="zoomable" src="../rokata.jpg" alt="路肩の写真" style="width: 40%; max-width: 200px;" />
         <p><strong>早織さんを待つまで、YouTubeは見せないでください。</strong></p>
       </section>
 


### PR DESCRIPTION
Closes #5


## 変更内容

- 保育園の入口・出口情報を追加（西側がGEO側出口、東側が王将側入口）
- 打刻クラス名を「1歳時」→「2歳児」に修正
- ② 知隼ピックアップの説明をファミサポ向けの声かけ方法に更新
- ③ 手順にお手拭きタオルに加えて水筒（水色サーモス）の取得を追加し、水筒の画像を追加
- ④ リュックの手順を更新し、リュック（モンスターズインク）の画像を追加
- ⑤ 靴の手順に出口注意喚起（GEO側）を追加
- 間取り図セクションの補足テキストを削除
- マンションの駐車案内を「駐車場21番」から「路肩または21番」に変更し、路肩の写真を追加

## テスト方法

- [ ] `docs/mother/index.html` をブラウザで開き、各セクションの表示を確認
- [ ] 追加した画像（水筒・リュック・路肩）が正しく表示されることを確認
- [ ] 手順番号（①〜⑤）が正しい順序で表示されることを確認
- [ ] 入口・出口の案内テキストが保育園住所セクションに表示されることを確認