### PR TITLE
保育園入園手順の説明文修正

### DIFF
--- a/docs/pickup-flow.html
+++ b/docs/pickup-flow.html
@@ -149,7 +149,7 @@
       <section class="card">
         <h2>手順</h2>
         <h3>横田保育園に入る</h3>
-        <p>インターホンを押す必要はありません。お迎えはインターホン不要です。柵の扉は開いています。</p>
+        <p>インターホンを押す必要はありません。お迎えはインターホン不要です。柵の鍵は施錠されていないので、そのまま入れます。</p>
         <img class="zoomable" src="./genkan1.jpg" alt="保育園入口" style="width: 40%; max-width: 200px;" />
         <p>入口の扉は、子供が園から出ないよう上に鍵が掛かっています。閉める時も、内鍵をしてください。</p>
         <img class="zoomable" src="./genkan2.jpg" alt="入口の鍵" style="width: 40%; max-width: 200px;" />


### PR DESCRIPTION
Closes #9


## 変更内容

- `docs/pickup-flow.html` の保育園入口に関する説明文を更新
  - 変更前: 「柵の扉は開いています。」
  - 変更後: 「柵の鍵は施錠されていないので、そのまま入れます。」
  - より具体的な表現に修正し、入園時の状況を正確に伝えるよう改善

## テスト方法

- `docs/pickup-flow.html` をブラウザで開き、「横田保育園に入る」セクションの説明文が正しく表示されることを確認